### PR TITLE
Reduce JavaScript usage for animations/transitions

### DIFF
--- a/tests/mainpage/hello.html
+++ b/tests/mainpage/hello.html
@@ -20,8 +20,7 @@
 	<script type="text/javascript" src="script.js"></script>
 
 </head>
-<!-- <body onload="animatenavitem('navHello')"> -->
-<body style="background-image: url(img/projRMIT.jpg);" onload="animatenavitem('navHello')">
+<body style="background-image: url(img/projRMIT.jpg);">
 	<div class="topnavContainer" id="topnavContainer">
 		<ul class="navgroup navleft">
 			<li><a class="navItem navItemactive" id="navHello" href="hello.html" >yuuiko says hello!<div class="selectedline"></div></a></li>

--- a/tests/mainpage/imagination.html
+++ b/tests/mainpage/imagination.html
@@ -21,7 +21,7 @@
 	<script type="text/javascript" src="script.js"></script>
 
 </head>
-<body onload="animatenavitem('navImagination')">
+<body>
 	<div class="topnavContainer" id="topnavContainer">
 		<ul class="navgroup navleft">
 			<li><a class="navItem" id="navHello" href="hello.html" >yuuiko says hello!<div class="selectedline"></div></a></li>

--- a/tests/mainpage/index.html
+++ b/tests/mainpage/index.html
@@ -20,7 +20,7 @@
 	<link rel="stylesheet" href="style.css">
 	<script type="text/javascript" src="script.js"></script>
 </head>
-<body onload="animatenavitem('navCreations')">
+<body>
 	<div class="topnavContainer" id="topnavContainer">
 		<ul class="navgroup navleft">
 			<li><a class="navItem" id="navHello" href="hello.html" >yuuiko says hello!<div class="selectedline"></div></a></li>

--- a/tests/mainpage/player.html
+++ b/tests/mainpage/player.html
@@ -21,7 +21,7 @@
 	<script type="text/javascript" src="script.js"></script>
 
 </head>
-<body onload="animatenavitem('navPlayer')">
+<body>
 	<div class="topnavContainer" id="topnavContainer">
 		<ul class="navgroup navleft">
 			<li><a class="navItem" target="_blank" rel="noopener noreferrer" id="navHello" href="hello.html" >yuuiko says hello!<div class="selectedline"></div></a></li>

--- a/tests/mainpage/script.js
+++ b/tests/mainpage/script.js
@@ -1,22 +1,3 @@
-function animatenavitem(divID) {
-	var item = document.getElementById(divID);
-	item.classList.add('navitemselected');
-	item.classList.remove('navItemactive');
-
-	// const height = document.querySelector("#height span");
-	var width = window.innerWidth;
-
-	// Insert values on load of page
-	if (width < 789) {
-		console.log("COMPACT MENUBAR FIRED ON LAUNCH, HIDE " + width);
-		setTimeout(function () {
-			document.getElementById('topnavContainer').classList.add('goneReducedToAtoms');
-			document.getElementById('topnavContainer').classList.add('hidden');
-		}, 250);
-	}
-}
-
-
 function showexpandedcompactmenu(divID) {
 	console.log("showwindow fired");
 	var item = document.getElementById(divID);

--- a/tests/mainpage/script.js
+++ b/tests/mainpage/script.js
@@ -1,33 +1,3 @@
-// // const height = document.querySelector("#height span");
-// var width = window.innerWidth;
-//
-// // Insert values on load of page
-// window.onload = function() {
-// 		if (width < 729) {
-// 				document.getElementById('topnavContainer').classList.add('goneReducedToAtoms');
-// 				document.getElementById('topnavContainer').classList.add('hidden');
-// 		}
-// 		else {
-// 			document.getElementById('topnavContainer').classList.remove('goneReducedToAtoms');
-// 			document.getElementById('topnavContainer').classList.remove('hidden');
-// 		}
-// };
-
-window.onresize = function() {
-	width = window.innerWidth;
-
-	console.log("fired " + width);
-
-	if (width < 789) {
-		document.getElementById('topnavContainer').classList.add('goneReducedToAtoms');
-		document.getElementById('topnavContainer').classList.add('hidden');
-	}
-	else {
-		document.getElementById('topnavContainer').classList.remove('goneReducedToAtoms');
-		document.getElementById('topnavContainer').classList.remove('hidden');
-	}
-};
-
 function animatenavitem(divID) {
 	var item = document.getElementById(divID);
 	item.classList.add('navitemselected');
@@ -50,27 +20,12 @@ function animatenavitem(divID) {
 function showexpandedcompactmenu(divID) {
 	console.log("showwindow fired");
 	var item = document.getElementById(divID);
-	item.classList.remove('goneReducedToAtoms');
-	setTimeout(function () {
-		item.classList.remove('hidden');
-	}, 10);
+	item.classList.add('reveal');
 }
 function hideexpandedcompactmenu(divID) {
 	console.log("PERMA hidewindow fired");
 	var item = document.getElementById(divID);
-
-	//reject further interactions while animating.
-	if (item.classList.contains('goneReducedToAtoms')) {
-	}
-	else {
-		item.classList.add('hidden');
-		item.classList.add('nointeract');
-
-		setTimeout(function () {
-			item.classList.remove('nointeract');
-			item.classList.add('goneReducedToAtoms');
-		}, 200);
-	}
+    item.classList.remove('reveal');
 }
 
 /* █ IRRELEVANTTT  ███████████████████████████████████████████ */

--- a/tests/mainpage/style.css
+++ b/tests/mainpage/style.css
@@ -275,11 +275,6 @@ a {
 }
 
 .navItemactive {
-	color: #0000FF;
-	background-color: rgba(150,150,150,0.3);
-}
-
-.navitemselected {
 	color: black !important;
 	display: inline-block !important;
 	pointer-events: none;
@@ -287,24 +282,28 @@ a {
 	margin: 0.5em 0.5em 0em;
 }
 
-.navitemselected > .selectedline {
-	background-color: rgba(0,0,0,1);
-	width : 100%;
-	height : 4px;
-	border-radius: 2px;
-	display: inline-block;
-	margin: 0;
+@keyframes revealSelectedLine {
+	0% {
+		width: 0;
+	}
+	100% {
+		width: 100%;
+	}
+}
+
+.navItemactive > .selectedline {
+	animation-name: revealSelectedLine;
+	animation-duration: 0.5s;
+	animation-fill-mode: forwards;
 }
 
 .selectedline {
 	background-color: rgba(0,0,0,1);
-	width : 0%;
-	height : 4px;
+	width: 0%;
+	height: 4px;
 	border-radius: 0;
 	display: inline-block;
 	margin: 0;
-
-	transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .topnavContainercompact {
@@ -477,7 +476,8 @@ a {
 		padding: 1em;
 		margin: 0px 6px;
 	}
-	.navitemselected {
+
+	.navItemactive {
 		padding: 1em;
 		margin: 0px 6px;
 		display: inline-block;
@@ -486,12 +486,15 @@ a {
 
 	.selectedline {
 		display: inline-block;
-		margin-top: 4px !important;
+		margin-top: 4px;
 		float: right;
-		width: 4px;}
-	.navitemselected > .selectedline {
+		width: 4px;
+	}
+
+	.navItemactive > .selectedline {
 		margin-top: 4px;
 		width: 40px;
+		animation: none;
 	}
 
 	.navgroup li {

--- a/tests/mainpage/style.css
+++ b/tests/mainpage/style.css
@@ -214,7 +214,6 @@ a {
 
 	display: flex;
 	justify-content: space-between;
-	transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 	transform-origin: top right;
 }
 
@@ -318,18 +317,6 @@ a {
 
 
 /* █████ SCRIPTING █████████████████████████████████████████████████ */
-.goneReducedToAtoms {
-	display: none !important;
-	cursor: none !important;
-	pointer-events: none !important;
-	user-select: none !important;
-}
-
-.hidden {
-	opacity: 0;
-	transform: scale(0.8);
-}
-
 .nointeract {
 	pointer-events: none;
 	-webkit-pointer-events: none;
@@ -438,13 +425,22 @@ a {
 		border-bottom: none;
 	}
 
+	#topnavContainer.reveal {
+		visibility: visible !important;
+		max-height: calc(100vh - 20px);
+		transition: visibility 0s, max-height 0.33s linear;
+	}
+
 	#topnavContainer {
+		visibility: hidden;
+		max-height: 0;
+		transition: max-height 0.33s linear, visibility 0s linear 0.33s;
+
 		display: flex !important;
 		flex-flow: column;
 		overflow-y: scroll;
 
 		width: auto;
-		max-height: calc(100vh - 20px);
 		right: 0;
 		left: auto;
 		margin: 10px;

--- a/tests/mainpage/support.html
+++ b/tests/mainpage/support.html
@@ -21,7 +21,7 @@
 	<script type="text/javascript" src="script.js"></script>
 
 </head>
-<body onload="animatenavitem('navSupport')">
+<body>
 	<div class="topnavContainer" id="topnavContainer">
 		<ul class="navgroup navleft">
 			<li><a class="navItem" id="navHello" href="hello.html" >yuuiko says hello!<div class="selectedline"></div></a></li>

--- a/tests/mainpage/talk.html
+++ b/tests/mainpage/talk.html
@@ -21,7 +21,7 @@
 	<script type="text/javascript" src="script.js"></script>
 
 </head>
-<body onload="animatenavitem('navContact')">
+<body>
 	<div class="topnavContainer" id="topnavContainer">
 		<ul class="navgroup navleft">
 			<li><a class="navItem" id="navHello" href="hello.html" >yuuiko says hello!<div class="selectedline"></div></a></li>


### PR DESCRIPTION
Transitions and animations should not be managed by JavaScript. 

- Replace the usage of CSS transition and JavaScript onload to animate the nav item selected line with CSS animation.  
- Drop window.onresize and ensure CSS "initial state" for collapsed mobile menu to be closed. 